### PR TITLE
Project quality assessment

### DIFF
--- a/frontend/components/PublicWebsiteManagement.tsx
+++ b/frontend/components/PublicWebsiteManagement.tsx
@@ -313,7 +313,7 @@ export default function PublicWebsiteManagement() {
             <label className="relative inline-flex items-center cursor-pointer">
               <input
                 type="checkbox"
-                checked={isEditing ? editForm.is_public : (profile?.is_public || editForm.is_public || false)}
+                checked={editForm.is_public || profile?.is_public || false}
                 onChange={(e) => setEditForm(prev => ({ ...prev, is_public: e.target.checked }))}
                 className="sr-only peer"
                 disabled={!isEditing}
@@ -330,7 +330,7 @@ export default function PublicWebsiteManagement() {
               </label>
               <input
                 type="text"
-                value={isEditing ? editForm.agent_name : (profile?.agent_name || editForm.agent_name || '')}
+                value={editForm.agent_name || profile?.agent_name || ''}
                 onChange={(e) => setEditForm(prev => ({ ...prev, agent_name: e.target.value }))}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 placeholder="Your professional name"
@@ -345,7 +345,7 @@ export default function PublicWebsiteManagement() {
               </label>
               <input
                 type="email"
-                value={isEditing ? editForm.email : (profile?.email || editForm.email || '')}
+                value={editForm.email || profile?.email || ''}
                 onChange={(e) => setEditForm(prev => ({ ...prev, email: e.target.value }))}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 placeholder="your.email@example.com"
@@ -361,7 +361,7 @@ export default function PublicWebsiteManagement() {
               </label>
               <input
                 type="tel"
-                value={isEditing ? editForm.phone : (profile?.phone || editForm.phone || '')}
+                value={editForm.phone || profile?.phone || ''}
                 onChange={(e) => setEditForm(prev => ({ ...prev, phone: e.target.value }))}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 placeholder="+1 (555) 123-4567"
@@ -374,7 +374,7 @@ export default function PublicWebsiteManagement() {
               </label>
               <input
                 type="text"
-                value={isEditing ? editForm.office_address : (profile?.office_address || editForm.office_address || '')}
+                value={editForm.office_address || profile?.office_address || ''}
                 onChange={(e) => setEditForm(prev => ({ ...prev, office_address: e.target.value }))}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 placeholder="123 Main St, City, State"
@@ -390,7 +390,7 @@ export default function PublicWebsiteManagement() {
             </label>
             <textarea
               rows={4}
-              value={isEditing ? editForm.bio : (profile?.bio || editForm.bio || '')}
+              value={editForm.bio || profile?.bio || ''}
               onChange={(e) => setEditForm(prev => ({ ...prev, bio: e.target.value }))}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               placeholder="Tell visitors about your experience, specialties, and what makes you unique..."
@@ -405,7 +405,7 @@ export default function PublicWebsiteManagement() {
             </label>
             <input
               type="text"
-              value={isEditing ? editForm.experience : (profile?.experience || editForm.experience || '')}
+              value={editForm.experience || profile?.experience || ''}
               onChange={(e) => setEditForm(prev => ({ ...prev, experience: e.target.value }))}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               placeholder="e.g., 10+ years in real estate, Certified Realtor"
@@ -423,7 +423,7 @@ export default function PublicWebsiteManagement() {
                 <label key={specialty} className="flex items-center">
                   <input
                     type="checkbox"
-                    checked={isEditing ? editForm.specialties.includes(specialty) : (profile?.specialties?.includes(specialty) || editForm.specialties.includes(specialty) || false)}
+                    checked={editForm.specialties.includes(specialty) || profile?.specialties?.includes(specialty) || false}
                     onChange={(e) => handleSpecialtyChange(specialty, e.target.checked)}
                     className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                     disabled={!isEditing}
@@ -444,7 +444,7 @@ export default function PublicWebsiteManagement() {
                 <label key={language} className="flex items-center">
                   <input
                     type="checkbox"
-                    checked={isEditing ? editForm.languages.includes(language) : (profile?.languages?.includes(language) || editForm.languages.includes(language) || false)}
+                    checked={editForm.languages.includes(language) || profile?.languages?.includes(language) || false}
                     onChange={(e) => handleLanguageChange(language, e.target.checked)}
                     className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                     disabled={!isEditing}


### PR DESCRIPTION
Fix agent profile form not displaying data by updating form field value logic.

The form's `value` and `checked` props incorrectly relied on the `isEditing` state, preventing data from `profile` or `editForm` from being displayed on initial load when `isEditing` was false. This change ensures the form consistently displays available data from `editForm` (populated on API call) or `profile` as a fallback.

---
<a href="https://cursor.com/background-agent?bcId=bc-19718e25-1d7a-4701-831f-775b99b49435">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19718e25-1d7a-4701-831f-775b99b49435">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

